### PR TITLE
FRCUserProgram is now given the CAP_SYS_NICE capability so it can set real-time priorities

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
@@ -76,6 +76,13 @@
                command="killall -q netconsole-host || :"/>
 
     <scp file="${wpilib.ant.dir}/robotCommand" todir="${username}@${target}:/home/lvuser/" password="${password}" trust="true"/>
+    <echo>[athena-deploy] Giving program CAP_SYS_NICE capability.</echo>
+    <sshexec host="${target}"
+       username="admin"
+       password="${password}"
+       trust="true"
+       failonerror="true"
+       command="setcap 'cap_sys_nice=pe' /home/lvuser/FRCUserProgram"/>
 
     <echo>[athena-deploy] Starting program.</echo>
     <sshexec host="${target}"


### PR DESCRIPTION
Since child processes can't inherit CAP_SYS_NICE from setuid processes, this commit adds an SSH command that invokes setcap instead. This works on recent kernels.
