### PR TITLE
Add checksum test to library deploy and deploy native libs.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
@@ -57,25 +57,30 @@
   </target>
 
   <target name="deploy" depends="get-target-ip, dependencies" description="Deploy the progam and start it running.">
+    <deploy-libs libs.name="WPI_Native_Libraries" libs.basedir="${wpilib.lib}">
+      <libs.local>
+        <fileset id="wpiNativeLibs.local" dir="${wpilib.lib}">
+          <include name="libHALAthena.so"/>
+          <include name="libntcore.so"/>
+          <include name="libwpilibc.so"/>
+          <include name="libwpiutil.so"/>
+        </fileset>
+      </libs.local>
+    </deploy-libs>
+    <deploy-libs libs.name="User_Libraries" libs.basedir="${userLibs.dir}">
+      <libs.local>
+        <fileset dir="${userLibs.dir}">
+          <include name="**/*.so"/>
+        </fileset>
+      </libs.local>
+    </deploy-libs>
+    
     <sshexec host="${target}"
          username="${username}"
          password="${password}"
          trust="true"
          failonerror="no"
          command="rm -f ${deploy.dir}/FRCUserProgram" />
-		 
-	<echo>[athena-deploy] Deploying shared libraries</echo>
-	<scp todir="${adminUsername}@${target}:${libDeploy.dir}" password="${adminPassword}" trust="true">
-		<fileset dir="${userLibs.dir}">
-			<include name="**/*.so"/>
-		</fileset>
-	</scp>
-	
-	<sshexec host="${target}"
-		username="${adminUsername}"
-		password="${adminPassword}"
-		trust="true"
-		command="chmod -R +x ${libDeploy.dir}"/>
 
     <echo>[athena-deploy] Copying code over.</echo>
     <scp file="${out.exe}" todir="${username}@${target}:${deploy.dir}" password="${password}" trust="true"/>
@@ -147,4 +152,58 @@
 	</assert>
 	<echo>roboRIO image version validated</echo>
   </target>
+  
+  <!-- libs.name should not contain spaces as it is used to name a file -->
+  <macrodef name="deploy-libs">
+    <attribute name="libs.name"/>
+    <attribute name="libs.basedir"/>
+    <element name="libs.local"/>
+    <sequential>
+      <local name="libs.local.notEmpty"/>
+      <local name="libs.local.checksum"/>
+      <local name="libs.deployed.checksum"/>
+      <local name="libs.local.modified.property"/>
+      
+      <delete file="@{libs.basedir}/@{libs.name}.properties"/>
+      <scp file="${adminUsername}@${target}:${libDeploy.dir}/@{libs.name}.properties" 
+           todir="@{libs.basedir}"
+           password="${adminPassword}" 
+           trust="true"
+           failonerror="false"/>
+      <restrict id="libs.local.modified">
+        <libs.local/>
+        <modified update="true"
+                  seldirs="true"
+                  cache="propertyfile"
+                  algorithm="digest"
+                  comparator="equal">
+          <param name="cache.cachefile" value="@{libs.basedir}/@{libs.name}.properties"/>
+          <param name="algorithm.algorithm" value="MD5"/>
+        </modified>
+      </restrict>
+      
+      <pathconvert refid="libs.local.modified" property="libs.local.modified.property" pathsep="," setonempty="false">
+        <globmapper from="@{libs.basedir}/*" to="*" handledirsep="true" />
+      </pathconvert>
+      
+      <if>
+        <isset property="libs.local.modified.property"/>
+        <then>
+          <echo message="Deploying libraries ${line.separator} ${libs.local.modified.property}"/>
+          <scp todir="${adminUsername}@${target}:${libDeploy.dir}" 
+               password="${adminPassword}" 
+               trust="true">
+            <fileset dir="@{libs.basedir}" includes="${libs.local.modified.property}"/>
+            <fileset file="@{libs.basedir}/@{libs.name}.properties"/>
+          </scp>
+          <sshexec host="${target}"
+                   username="${adminUsername}"
+                   password="${adminPassword}"
+                   trust="true"
+                   command="chmod -R +x ${libDeploy.dir}"
+          />
+        </then>
+      </if>
+    </sequential>
+  </macrodef>
 </project>

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.properties
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.properties
@@ -15,6 +15,7 @@ roboRIOJRE.dir=/usr/local/frc/JRE
 # Libraries to use
 wpilib=${user.home}/wpilib/java/${version}
 wpilib.lib=${wpilib}/lib
+wpilib.native.lib=${wpilib.lib}/native
 wpilib.jar=${wpilib.lib}/WPILib.jar
 wpilib.sources=${wpilib.lib}/WPILib-sources.jar
 networktables.jar=${wpilib.lib}/NetworkTables.jar

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -108,20 +108,23 @@
      for you, you can remove the clean here, just be sure to do a full rebuild after you've changed any constants.
      Reference: http://stackoverflow.com/questions/6430001/ant-doesnt-recompile-constants -->
   <target name="deploy" depends="clean,jar,get-target-ip,dependencies" description="Deploy the jar and start the program running.">
+
+    <deploy-libs libs.name="WPI_Native_Libraries" libs.basedir="${wpilib.native.lib}">
+      <libs.local>
+        <fileset id="wpiNativeLibs.local" dir="${wpilib.native.lib}">
+          <include name="**/*.so"/>
+        </fileset>
+      </libs.local>
+    </deploy-libs>
+    
+    <deploy-libs libs.name="User_Libraries" libs.basedir="${userLibs.dir}">
+      <libs.local>
+        <fileset dir="${userLibs.dir}">
+          <include name="**/*.so"/>
+        </fileset>
+      </libs.local>
+    </deploy-libs>
   
-    <echo>[athena-deploy] Deploying shared libraries</echo>
-  	<scp todir="${adminUsername}@${target}:${libDeploy.dir}" password="${adminPassword}" trust="true">
-		<fileset dir="${userLibs.dir}">
-			<include name="**/*.so"/>
-		</fileset>
-	</scp>
-	
-	<sshexec host="${target}"
-		username="${adminUsername}"
-		password="${adminPassword}"
-		trust="true"
-		command="chmod -R +x ${libDeploy.dir}"/>
-	
     <echo>[athena-deploy] Copying code over.</echo>
     <scp file="${dist.jar}" todir="${username}@${target}:${deploy.dir}" password="${password}" trust="true"/>
 
@@ -153,6 +156,21 @@
   </target>
 
   <target name="debug-deploy" depends="jar,get-target-ip,dependencies" description="Deploy the jar and start the program running.">
+    <deploy-libs libs.name="WPI_Native_Libraries" libs.basedir="${wpilib.native.lib}">
+      <libs.local>
+        <fileset id="wpiNativeLibs.local" dir="${wpilib.native.lib}">
+          <include name="**/*.so"/>
+        </fileset>
+      </libs.local>
+    </deploy-libs>
+    
+    <deploy-libs libs.name="User_Libraries" libs.basedir="${userLibs.dir}">
+      <libs.local>
+        <fileset dir="${userLibs.dir}">
+          <include name="**/*.so"/>
+        </fileset>
+      </libs.local>
+    </deploy-libs>
     <echo>[athena-deploy] Copying code over.</echo>
     <scp file="${dist.jar}" todir="${username}@${target}:${deploy.dir}" password="${password}" trust="true"/>
   	<!-- The remoteDebugCommand file is used by /usr/local/frc/bin/frcRunRobot.sh on the roboRIO  -->
@@ -241,4 +259,58 @@
 		failonerror="true"
         command="test -d ${roboRIOJRE.dir}"/>
   </target>
+  
+  <!-- libs.name should not contain spaces as it is used to name a file -->
+  <macrodef name="deploy-libs">
+    <attribute name="libs.name"/>
+    <attribute name="libs.basedir"/>
+    <element name="libs.local"/>
+    <sequential>
+      <local name="libs.local.notEmpty"/>
+      <local name="libs.local.checksum"/>
+      <local name="libs.deployed.checksum"/>
+      <local name="libs.local.modified.property"/>
+      
+      <delete file="@{libs.basedir}/@{libs.name}.properties"/>
+      <scp file="${adminUsername}@${target}:${libDeploy.dir}/@{libs.name}.properties" 
+           todir="@{libs.basedir}"
+           password="${adminPassword}" 
+           trust="true"
+           failonerror="false"/>
+      <restrict id="libs.local.modified">
+        <libs.local/>
+        <modified update="true"
+                  seldirs="true"
+                  cache="propertyfile"
+                  algorithm="digest"
+                  comparator="equal">
+          <param name="cache.cachefile" value="@{libs.basedir}/@{libs.name}.properties"/>
+          <param name="algorithm.algorithm" value="MD5"/>
+        </modified>
+      </restrict>
+      
+      <pathconvert refid="libs.local.modified" property="libs.local.modified.property" pathsep="," setonempty="false">
+        <globmapper from="@{libs.basedir}/*" to="*" handledirsep="true" />
+      </pathconvert>
+      
+      <if>
+        <isset property="libs.local.modified.property"/>
+        <then>
+          <echo message="Deploying libraries ${line.separator} ${libs.local.modified.property}"/>
+          <scp todir="${adminUsername}@${target}:${libDeploy.dir}" 
+               password="${adminPassword}" 
+               trust="true">
+            <fileset dir="@{libs.basedir}" includes="${libs.local.modified.property}"/>
+            <fileset file="@{libs.basedir}/@{libs.name}.properties"/>
+          </scp>
+          <sshexec host="${target}"
+                   username="${adminUsername}"
+                   password="${adminPassword}"
+                   trust="true"
+                   command="chmod -R +x ${libDeploy.dir}"
+          />
+        </then>
+      </if>
+    </sequential>
+  </macrodef>
 </project>


### PR DESCRIPTION
Libraries should now only deploy on change (all deploy on any change)
Fixes #27, #34, and #40 (but should not require any of the commits related to #34 to function, it will just skip the native libs in Java if they aren't there)
