### PR TITLE
Updates maven artifacts to use new allwpilib repo names

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/pom.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/pom.xml
@@ -62,10 +62,22 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>edu.wpi.first.wpilib.cmake</groupId>
-                                    <artifactId>cpp-root</artifactId>
+                                    <groupId>edu.wpi.first.wpilibc</groupId>
+                                    <artifactId>athena</artifactId>
                                     <type>zip</type>
-                                    <destFileName>cpp-root.jar</destFileName>
+                                    <destFileName>athena.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>edu.wpi.first.wpilib</groupId>
+                                    <artifactId>athena-runtime</artifactId>
+                                    <type>zip</type>
+                                    <destFileName>athena-runtime.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>edu.wpi.first.wpilib</groupId>
+                                    <artifactId>hal</artifactId>
+                                    <type>zip</type>
+                                    <destFileName>hal.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}</outputDirectory>
@@ -114,7 +126,9 @@
                             <target>
                                 <unzip dest="${cpp-zip}">
                                     <fileset dir="${project.build.directory}">
-                                        <include name="cpp-root.jar"/>
+                                        <include name="athena.jar"/>
+                                        <include name="hal.jar"/>
+                                        <include name="athena-runtime.jar"/>
                                     </fileset>
                                 </unzip>
                             </target>
@@ -141,8 +155,20 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>edu.wpi.first.wpilib.cmake</groupId>
-            <artifactId>cpp-root</artifactId>
+            <groupId>edu.wpi.first.wpilibc</groupId>
+            <artifactId>athena</artifactId>
+            <version>1.0.0</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>edu.wpi.first.wpilib</groupId>
+            <artifactId>athena-runtime</artifactId>
+            <version>1.0.0</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>edu.wpi.first.wpilib</groupId>
+            <artifactId>hal</artifactId>
             <version>1.0.0</version>
             <type>zip</type>
         </dependency>

--- a/edu.wpi.first.wpilib.plugins.java/pom.xml
+++ b/edu.wpi.first.wpilib.plugins.java/pom.xml
@@ -55,7 +55,33 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>2.8</version>
                 <executions>
-
+                    <execution>
+                      <id>extract-native-dependencies</id>
+                      <phase>compile</phase>
+                      <goals>
+                        <goal>unpack</goal>
+                      </goals>
+                      <configuration>
+                        <artifactItems>
+                          <artifactItem>
+                              <groupId>edu.wpi.first.wpilibj</groupId>
+                              <artifactId>athena-jni</artifactId>
+                              <type>jar</type>
+                              <includes>**/*.so,**/*.so.debug</includes>
+                              <excludes>**/*.MF,**/*.a,**/*.h</excludes>
+                              <outputDirectory>${java-zip}/lib/native</outputDirectory>
+                          </artifactItem>
+                          <artifactItem>
+                              <groupId>edu.wpi.first.wpilib</groupId>
+                              <artifactId>athena-runtime</artifactId>
+                              <type>zip</type>
+                              <includes>**/*.so,**/*.so.debug</includes>
+                              <excludes>**/*.MF,**/*.a,**/*.h</excludes>
+                              <outputDirectory>${java-zip}/lib/native</outputDirectory>
+                          </artifactItem>
+                        </artifactItems>
+                      </configuration>
+                    </execution>
                     <!-- Fetch the dependencies needed to build the jar.zip file. -->
                     <execution>
                         <id>fetch-jar-zip-dependencies</id>
@@ -76,7 +102,7 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>edu.wpi.first.wpilibj</groupId>
-                                    <artifactId>wpilibJavaFinal</artifactId>
+                                    <artifactId>athena</artifactId>
                                     <type>jar</type>
                                     <destFileName>WPILib.jar</destFileName>
                                     <outputDirectory>${java-zip}/lib</outputDirectory>
@@ -91,7 +117,7 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>edu.wpi.first.wpilibj</groupId>
-                                    <artifactId>wpilibJavaFinal</artifactId>
+                                    <artifactId>athena</artifactId>
                                     <classifier>sources</classifier>
                                     <outputDirectory>${java-zip}/lib</outputDirectory>
                                     <destFileName>WPILib-sources.jar</destFileName>
@@ -100,7 +126,7 @@
                                 <!-- Javadoc -->
                                 <artifactItem>
                                     <groupId>edu.wpi.first.wpilibj</groupId>
-                                    <artifactId>wpilibJavaFinal</artifactId>
+                                    <artifactId>athena</artifactId>
                                     <classifier>javadoc</classifier>
                                     <outputDirectory>${java-zip}/javadoc-jar</outputDirectory>
                                 </artifactItem>
@@ -231,13 +257,25 @@
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.wpilibj</groupId>
-            <artifactId>wpilibJavaFinal</artifactId>
+            <artifactId>athena</artifactId>
             <version>0.1.0-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.wpilibj</groupId>
-            <artifactId>wpilibJavaFinal</artifactId>
+            <artifactId>athena-jni</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>edu.wpi.first.wpilib</groupId>
+            <artifactId>athena-runtime</artifactId>
+            <version>1.0.0</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>edu.wpi.first.wpilibj</groupId>
+            <artifactId>athena</artifactId>
             <version>0.1.0-SNAPSHOT</version>
             <classifier>sources</classifier>
         </dependency>


### PR DESCRIPTION
C++ libraries still in same location, Java java libraries in same
location, java native libraries moved to $javaLib/native/lib
