### PR TITLE
Enables Image 7 for plugins

### DIFF
--- a/ni_image.properties
+++ b/ni_image.properties
@@ -1,2 +1,2 @@
-roboRIOAllowedImages=6
+roboRIOAllowedImages=6,7
 roboRIOAllowedYear=2017


### PR DESCRIPTION
Looking through the changes and other testing, v6 or v7 are basically
identical, so the plugins can support both. CSV separated images works
properly in eclipse too.