### PR TITLE
Fixes debugging for C++ in Neon

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/META-INF/MANIFEST.MF
+++ b/edu.wpi.first.wpilib.plugins.cpp/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.cdt.debug.ui;bundle-version="7.2.0",
  org.eclipse.cdt.launch;bundle-version="7.1.0",
  org.eclipse.cdt.launch.remote;bundle-version="2.4.0",
- org.eclipse.core.variables
+ org.eclipse.core.variables,
+ org.eclipse.remote.core;bundle-version="2.0.0";resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: edu.wpi.first.wpilib.plugins.cpp,

--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/java/edu/wpi/first/wpilib/plugins/cpp/launching/DeployLaunchShortcut.java
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/java/edu/wpi/first/wpilib/plugins/cpp/launching/DeployLaunchShortcut.java
@@ -18,6 +18,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfigurationType;
@@ -175,8 +176,8 @@ public class DeployLaunchShortcut implements ILaunchShortcut
 
 			// Kill running program before using RSE as RSE can't
 			WPILibCPPPlugin.logInfo("Running ant file: " + activeProj.getLocation().toOSString() + File.separator + "build.xml");
-			WPILibCPPPlugin.logInfo("Targets: kill-program, Mode: " + mode);
-			ILaunch killAnt = AntLauncher.runAntFile(new File (activeProj.getLocation().toOSString() + File.separator + "build.xml"), "kill-program", null, mode);
+			WPILibCPPPlugin.logInfo("Targets: debug-prepare, Mode: " + mode);
+			ILaunch killAnt = AntLauncher.runAntFile(new File (activeProj.getLocation().toOSString() + File.separator + "build.xml"), "debug-prepare", null, mode);
 			int tries = 0;
 			try{
 				while(!killAnt.isTerminated() && tries < DEBUG_KILL_WAIT_TRIES){
@@ -204,7 +205,13 @@ public class DeployLaunchShortcut implements ILaunchShortcut
 		ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
 		ILaunchConfigurationType type = manager.getLaunchConfigurationType(ICDTLaunchConfigurationConstants.ID_LAUNCH_C_REMOTE_APP);
 		int teamNumber = WPILibCore.getDefault().getTeamNumber(activeProj);
-		String remote_connection = RSEUtils.getTarget(teamNumber).getName();
+    String remote_connection = "";
+    if(Platform.getBundle("org.eclipse.platform").getVersion().getMinor() > 5 )
+    {
+      remote_connection = RemoteUtils.getTarget(teamNumber).getName();
+    } else{
+      remote_connection = RSEUtils.getTarget(teamNumber).getName();
+    }
 
 		ILaunchConfigurationWorkingCopy config = type.newInstance(null, activeProj.getName());
 		config.setAttribute(ICDTLaunchConfigurationConstants.ATTR_COREFILE_PATH, "");

--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/java/edu/wpi/first/wpilib/plugins/cpp/launching/RemoteUtils.java
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/java/edu/wpi/first/wpilib/plugins/cpp/launching/RemoteUtils.java
@@ -1,0 +1,58 @@
+package edu.wpi.first.wpilib.plugins.cpp.launching;
+
+import java.util.Arrays;
+
+import org.eclipse.remote.core.IRemoteServicesManager;
+import org.eclipse.remote.core.IRemoteConnectionType;
+import org.eclipse.remote.core.IRemoteConnection;
+import org.eclipse.remote.core.IRemoteConnectionWorkingCopy;
+import org.eclipse.remote.core.exception.RemoteConnectionException;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import edu.wpi.first.wpilib.plugins.cpp.WPILibCPPPlugin;
+
+public class RemoteUtils {
+  
+  /**
+   * Return the OSGi service with the given service interface.
+   *
+   * @param service service interface
+   * @return the specified service or null if it's not registered
+   */
+  public static <T> T getService(Class<T> service) {
+          BundleContext context = WPILibCPPPlugin.getDefault().getBundle().getBundleContext();
+          ServiceReference<T> ref = context.getServiceReference(service);
+          return ref != null ? context.getService(ref) : null;
+  }
+
+	public static IRemoteConnection getTarget(int teamNumber) {
+		// The ip address based on the team number
+        //String hostName = "10."+(teamNumber/100)+"."+(teamNumber%100)+".2";
+        //String connectionName = hostName; //"Team "+teamNumber;
+		String hostName = "roboRIO-" + teamNumber + "-FRC.local";
+		String connectionName = hostName;
+    
+    IRemoteServicesManager mgr = getService(IRemoteServicesManager.class);
+    IRemoteConnectionType connType = mgr.getConnectionType("org.eclipse.remote.JSch");
+    IRemoteConnection connection = connType.getConnection(connectionName);
+    if(connection == null)
+    {
+      try {
+        IRemoteConnectionWorkingCopy connWC = connType.newConnection(connectionName);
+        connWC.setAttribute("JSCH_ADDRESS_ATTR", hostName);
+        connWC.setAttribute("JSCH_USERNAME_ATTR", "lvuser");
+        connWC.setAttribute("JSCH_PASSWORD_ATTR", "");
+        connWC.setAttribute("JSCH_IS_PASSWORD_ATTR", "true");
+        connWC.setAttribute("JSCH_USE_LOGIN_SHELL_ATTR", "false");
+        return connWC.save();
+      } catch (RemoteConnectionException e) {
+        WPILibCPPPlugin.logError("Error creating remote connection", e);
+        return null;
+      }
+    } else
+    {
+      return connection;
+    }
+  }
+}

--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
@@ -118,6 +118,16 @@
 
   </target>
 
+  <target name="debug-prepare" depends="kill-program">
+    <scp file="${wpilib.ant.dir}/locale" todir="${adminUsername}@${target}:/bin/" password="${adminPassword}" trust="true"/>
+    <sshexec host="${target}"
+             username="${adminUsername}"
+             password="${adminPassword}"
+             trust="true"
+             command="chmod -R +x /bin/locale"
+    />
+  </target>
+    
   <target name="kill-program" depends="get-target-ip" description="Kill the currently running FRC program">
 	  <sshexec host="${target}"
 		   username="${username}"

--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/locale
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/locale
@@ -1,0 +1,4 @@
+#!/bin/sh
+#locale hack script. Required for neon CPP debugging
+
+echo "UTF-8"

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
             <url>${repo.remote}</url>
         </repository>
         <repository>
-            <id>juno</id>
+            <id>neon</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/releases/luna</url>
+            <url>http://download.eclipse.org/releases/neon</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
CDT switched over from RSE to org.eclipse.remote so we use that if Neon and RSE if older.
closes #54 