### PR TITLE
Moved LD_LIBRARY_PATH to java.library.path to address part of wpilibs…

### DIFF
--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/robotCommand
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/robotCommand
@@ -1,2 +1,1 @@
-env LD_LIBRARY_PATH=/opt/GenICam_v3_0_NI/bin/Linux32_ARM/:/usr/local/frc/lib /usr/local/frc/JRE/bin/java -jar /home/lvuser/FRCUserProgram.jar
-
+/usr/local/frc/JRE/bin/java -Djava.library.path=/usr/local/frc/lib/ -jar /home/lvuser/FRCUserProgram.jar

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/robotDebugCommand
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/robotDebugCommand
@@ -1,2 +1,2 @@
-/usr/local/frc/JRE/bin/java -Djava.library.path=/usr/local/frc/lib -XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=8348,server=y,suspend=y -jar /home/lvuser/FRCUserProgram.jar
+/usr/local/frc/JRE/bin/java -Djava.library.path=/usr/local/frc/lib/ -XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=8348,server=y,suspend=y -jar /home/lvuser/FRCUserProgram.jar
 

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/robotDebugCommand
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/robotDebugCommand
@@ -1,2 +1,2 @@
-env LD_LIBRARY_PATH=/opt/GenICam_v3_0_NI/bin/Linux32_ARM/:/usr/local/frc/lib /usr/local/frc/JRE/bin/java -XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=8348,server=y,suspend=y -jar /home/lvuser/FRCUserProgram.jar
+/usr/local/frc/JRE/bin/java -Djava.library.path=/usr/local/frc/lib -XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=8348,server=y,suspend=y -jar /home/lvuser/FRCUserProgram.jar
 

--- a/ni_image.properties
+++ b/ni_image.properties
@@ -1,2 +1,2 @@
-roboRIOAllowedImages=6,7,8
+roboRIOAllowedImages=8
 roboRIOAllowedYear=2017


### PR DESCRIPTION
…uite/java-installer#18. Also removed the GenICAM path, as it's no longer necessary. @Kevin-OConnor @PeterJohnson. /cc @sciencewhiz.