### PR TITLE
Added missing libs.deployDir

### DIFF
--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -189,7 +189,7 @@
   </target>
 
   <target name="debug-deploy" depends="jar,get-target-ip,dependencies" description="Deploy the jar and start the program running.">
-    <deploy-libs libs.name="WPI_Native_Libraries" libs.basedir="${wpilib.native.lib}">
+    <deploy-libs libs.name="WPI_Native_Libraries" libs.basedir="${wpilib.native.lib}" libs.deployDir="${libDeploy.dir}">
       <libs.local>
         <fileset id="wpiNativeLibs.local" dir="${wpilib.native.lib}">
           <include name="**/*.so"/>


### PR DESCRIPTION
Debug deploy target appeared to be missing libs.deployDir , which was preventing a successful debug deploy from eclipse. I"m not sure if this is all of the required changes (as I still have to manually restart the remote java application), but this does allow the deploy to go through as expected.