### PR TITLE
Use parallel + hostinfo to get IP address when deploying.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
@@ -23,6 +23,7 @@
     <property name="ant.enable.asserts" value="true"/>
     <assert name="team-number" exists="true" message="Team number not set. Go to Window->Preferences->WPILib Preferences to set it."/>
 
+    <echo>Finding roboRIO, please ignore any [hostinfo] error messages</echo>
     <var name="target" unset="true"/>
     <trycatch>
       <try>

--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
@@ -21,50 +21,92 @@
 
   <target name="get-target-ip">
     <property name="ant.enable.asserts" value="true"/>
-	<assert name="team-number" exists="true" message="Team number not set. Go to Window->Preferences->WPILib Preferences to set it."/>
-    <property name="target" value="roboRIO-${team-number}-FRC.local" />
-	<echo>Trying Target: ${target}</echo>
-	 <if>
-		<isreachable host="${target}" timeout="5"/>
-	  <then>
-		<echo>roboRIO found via mDNS</echo>
-	  </then>
-	  <else>
-		<var name="target" unset="true"/>
-		<echo> roboRIO not found via mDNS, falling back to DNS</echo>
-	  	<property name="target" value="roboRIO-${team-number}-FRC.lan"/>
-		<if>
-			<isreachable host="${target}" timeout="5"/>
-		  <then>
-			<echo>roboRIO found via DNS</echo>
-		  </then>
-	  	  <else>
-			<var name="target" unset="true"/>
-			<echo> roboRIO not found via DNS, falling back to static USB</echo>
-			<property name="target" value="172.22.11.2"/>
-			<if>
-				<isreachable host="${target}" timeout="5"/>
-			  <then>
-				<echo>roboRIO found via static USB</echo>
-			  </then>
-			  <else>
-				<var name="target" unset="true"/>
-				<math result="ip.upper" operand1="${team-number}" operation="/" operand2="100" datatype="int"/>
-				<math result="ip.lower" operand1="${team-number}" operation="%" operand2="100" datatype="int"/>
-				<property name="target" value="10.${ip.upper}.${ip.lower}.2"/>
-				<echo>roboRIO not found via USB, falling back to static address of ${target}</echo>
-				<assert name="roboRIOFound" message="roboRIO not found, please check that the roboRIO is connected, imaged and that the team number is set properly in Eclipse">
-					<bool>
-						<isreachable host="${target}" timeout="5"/>
-					</bool>
-				</assert>
-				<echo>roboRIO found via Ethernet static</echo>
-			  </else>
-			</if>
-	  	  </else>
-	  	</if>
-	  </else>
-	 </if>
+    <assert name="team-number" exists="true" message="Team number not set. Go to Window->Preferences->WPILib Preferences to set it."/>
+
+    <var name="target" unset="true"/>
+    <trycatch>
+      <try>
+        <parallel failonany="true">
+          <sequential>
+            <echo>Trying mDNS: roboRIO-${team-number}-FRC.local</echo>
+            <hostinfo prefix="targethost_local" host="roboRIO-${team-number}-FRC.local" />
+            <if>
+              <not>
+                <equals arg1="${targethost_local.ADDR4}" arg2="0.0.0.0"/>
+              </not>
+              <then>
+                <echo>Resolved mDNS to ${targethost_local.ADDR4}</echo>
+                <if>
+                  <socket server="${targethost_local.ADDR4}" port="80"/>
+                  <then>
+                    <property name="target" value="${targethost_local.ADDR4}"/>
+                    <fail>${targethost_local.ADDR4}</fail>
+                  </then>
+                </if>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <echo>Trying DNS: roboRIO-${team-number}-FRC.lan</echo>
+            <hostinfo prefix="targethost_lan" host="roboRIO-${team-number}-FRC.lan" />
+            <if>
+              <not>
+                <equals arg1="${targethost_lan.ADDR4}" arg2="0.0.0.0"/>
+              </not>
+              <then>
+                <echo>Resolved DNS to ${targethost_lan.ADDR4}</echo>
+                <if>
+                  <socket server="${targethost_lan.ADDR4}" port="80"/>
+                  <then>
+                    <property name="target" value="${targethost_lan.ADDR4}"/>
+                    <fail>${targethost_lan.ADDR4}</fail>
+                  </then>
+                </if>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <echo>Trying USB: 172.22.11.2</echo>
+            <if>
+              <socket server="172.22.11.2" port="80"/>
+              <then>
+                <property name="target" value="172.22.11.2"/>
+                <fail>172.22.11.2</fail>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <math result="ip.upper" operand1="${team-number}" operation="/" operand2="100" datatype="int"/>
+            <math result="ip.lower" operand1="${team-number}" operation="%" operand2="100" datatype="int"/>
+            <property name="targethost_ip" value="10.${ip.upper}.${ip.lower}.2"/>
+            <echo>Trying Static Ethernet: ${targethost_ip}</echo>
+            <if>
+              <socket server="${targethost_ip}" port="80"/>
+              <then>
+                <property name="target" value="${targethost_ip}"/>
+                <fail>${targethost_ip}</fail>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <sleep seconds="20"/>
+            <fail></fail>
+          </sequential>
+        </parallel>
+      </try>
+      <catch>
+      </catch>
+    </trycatch>
+
+    <if>
+      <isset property="target"/>
+      <then>
+        <echo>roboRIO found at ${target}</echo>
+      </then>
+      <else>
+        <assert name="roboRIOFound" message="roboRIO not found, please check that the roboRIO is connected, imaged and that the team number is set properly in Eclipse"/>
+      </else>
+    </if>
   </target>
 
   <target name="deploy" depends="get-target-ip, dependencies" description="Deploy the progam and start it running.">
@@ -97,7 +139,7 @@
 
     <sshexec host="${target}"
          username="${adminUsername}"
-         password="${password}"
+         password="${adminPassword}"
          trust="true"
          command="ldconfig" />
 
@@ -107,8 +149,8 @@
      <!-- Suppress the exit status so that if no netconsole was running then
           it doesn't show up red on the output. -->
     <sshexec host="${target}"
-               username="admin"
-               password="${password}"
+               username="${adminUsername}"
+               password="${adminPassword}"
                trust="true"
                failonerror="false"
                command="killall -q netconsole-host || :"/>
@@ -125,8 +167,8 @@
     <scp file="${wpilib.ant.dir}/robotCommand" todir="${username}@${target}:/home/lvuser/" password="${password}" trust="true"/>
     <echo>[athena-deploy] Giving program CAP_SYS_NICE capability.</echo>
     <sshexec host="${target}"
-       username="admin"
-       password="${password}"
+       username="${adminUsername}"
+       password="${adminPassword}"
        trust="true"
        failonerror="true"
        command="setcap 'cap_sys_nice=pe' /home/lvuser/FRCUserProgram"/>

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -21,50 +21,92 @@
 
   <target name="get-target-ip">
     <property name="ant.enable.asserts" value="true"/>
-	<assert name="team-number" exists="true" message="Team number not set. Go to Window->Preferences->WPILib Preferences to set it."/>
-    <property name="target" value="roboRIO-${team-number}-FRC.local" />
-	<echo>Trying Target: ${target}</echo>
-	 <if>
-		<isreachable host="${target}" timeout="5"/>
-	  <then>
-		<echo>roboRIO found via mDNS</echo>
-	  </then>
-	  <else>
-		<var name="target" unset="true"/>
-		<echo> roboRIO not found via mDNS, falling back to DNS</echo>
-	  	<property name="target" value="roboRIO-${team-number}-FRC.lan"/>
-		<if>
-			<isreachable host="${target}" timeout="5"/>
-		  <then>
-			<echo>roboRIO found via DNS</echo>
-		  </then>
-	  	  <else>
-			<var name="target" unset="true"/>
-			<echo> roboRIO not found via DNS, falling back to static USB</echo>
-			<property name="target" value="172.22.11.2"/>
-			<if>
-				<isreachable host="${target}" timeout="5"/>
-			  <then>
-				<echo>roboRIO found via static USB</echo>
-			  </then>
-			  <else>
-				<var name="target" unset="true"/>
-				<math result="ip.upper" operand1="${team-number}" operation="/" operand2="100" datatype="int"/>
-				<math result="ip.lower" operand1="${team-number}" operation="%" operand2="100" datatype="int"/>
-				<property name="target" value="10.${ip.upper}.${ip.lower}.2"/>
-				<echo>roboRIO not found via USB, falling back to static address of ${target}</echo>
-				<assert name="roboRIOFound" message="roboRIO not found, please check that the roboRIO is connected, imaged and that the team number is set properly in Eclipse">
-					<bool>
-						<isreachable host="${target}" timeout="5"/>
-					</bool>
-				</assert>
-				<echo>roboRIO found via Ethernet static</echo>
-			  </else>
-			</if>
-	  	  </else>
-	  	</if>
-	  </else>
-	 </if>
+    <assert name="team-number" exists="true" message="Team number not set. Go to Window->Preferences->WPILib Preferences to set it."/>
+
+    <var name="target" unset="true"/>
+    <trycatch>
+      <try>
+        <parallel failonany="true">
+          <sequential>
+            <echo>Trying mDNS: roboRIO-${team-number}-FRC.local</echo>
+            <hostinfo prefix="targethost_local" host="roboRIO-${team-number}-FRC.local" />
+            <if>
+              <not>
+                <equals arg1="${targethost_local.ADDR4}" arg2="0.0.0.0"/>
+              </not>
+              <then>
+                <echo>Resolved mDNS to ${targethost_local.ADDR4}</echo>
+                <if>
+                  <socket server="${targethost_local.ADDR4}" port="80"/>
+                  <then>
+                    <property name="target" value="${targethost_local.ADDR4}"/>
+                    <fail>${targethost_local.ADDR4}</fail>
+                  </then>
+                </if>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <echo>Trying DNS: roboRIO-${team-number}-FRC.lan</echo>
+            <hostinfo prefix="targethost_lan" host="roboRIO-${team-number}-FRC.lan" />
+            <if>
+              <not>
+                <equals arg1="${targethost_lan.ADDR4}" arg2="0.0.0.0"/>
+              </not>
+              <then>
+                <echo>Resolved DNS to ${targethost_lan.ADDR4}</echo>
+                <if>
+                  <socket server="${targethost_lan.ADDR4}" port="80"/>
+                  <then>
+                    <property name="target" value="${targethost_lan.ADDR4}"/>
+                    <fail>${targethost_lan.ADDR4}</fail>
+                  </then>
+                </if>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <echo>Trying USB: 172.22.11.2</echo>
+            <if>
+              <socket server="172.22.11.2" port="80"/>
+              <then>
+                <property name="target" value="172.22.11.2"/>
+                <fail>172.22.11.2</fail>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <math result="ip.upper" operand1="${team-number}" operation="/" operand2="100" datatype="int"/>
+            <math result="ip.lower" operand1="${team-number}" operation="%" operand2="100" datatype="int"/>
+            <property name="targethost_ip" value="10.${ip.upper}.${ip.lower}.2"/>
+            <echo>Trying Static Ethernet: ${targethost_ip}</echo>
+            <if>
+              <socket server="${targethost_ip}" port="80"/>
+              <then>
+                <property name="target" value="${targethost_ip}"/>
+                <fail>${targethost_ip}</fail>
+              </then>
+            </if>
+          </sequential>
+          <sequential>
+            <sleep seconds="20"/>
+            <fail></fail>
+          </sequential>
+        </parallel>
+      </try>
+      <catch>
+      </catch>
+    </trycatch>
+
+    <if>
+      <isset property="target"/>
+      <then>
+        <echo>roboRIO found at ${target}</echo>
+      </then>
+      <else>
+        <assert name="roboRIOFound" message="roboRIO not found, please check that the roboRIO is connected, imaged and that the team number is set properly in Eclipse"/>
+      </else>
+    </if>
   </target>
 
   <target name="compile" description="Compile the source code.">
@@ -149,15 +191,15 @@
 
     <sshexec host="${target}"
          username="${adminUsername}"
-         password="${password}"
+         password="${adminPassword}"
          trust="true"
          command="ldconfig" />
 
      <!-- Suppress the exit status so that if no netconsole was running then
           it doesn't show up red on the output. -->
       <sshexec host="${target}"
-               username="admin"
-               password="${password}"
+               username="${adminUsername}"
+               password="${adminPassword}"
                trust="true"
                failonerror="false"
                command="killall -q netconsole-host || :"/>

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -23,6 +23,7 @@
     <property name="ant.enable.asserts" value="true"/>
     <assert name="team-number" exists="true" message="Team number not set. Go to Window->Preferences->WPILib Preferences to set it."/>
 
+    <echo>Finding roboRIO, please ignore any [hostinfo] error messages</echo>
     <var name="target" unset="true"/>
     <trycatch>
       <try>


### PR DESCRIPTION
This avoids multiple DNS/mDNS lookups and performs the lookups in parallel.

Also fix up a couple of adminUsername / adminPassword cases.