### PR TITLE
Fix roboRIO image version detection in presence of EOL.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
@@ -179,12 +179,15 @@
 
   <target name="dependencies" depends="get-target-ip">
     <property name="ant.enable.asserts" value="true"/>
-	<post to="http://${target}/nisysapi/server" logfile="sysProps.xml" verbose="false" encoding="UTF-16LE" append="false">
+	<post to="http://${target}/nisysapi/server" property="roboRIOSysValuesUTF16" verbose="false" encoding="UTF-16LE" append="false">
 		<prop name="Function" value="GetPropertiesOfItem"/>
 		<prop name="Plugins" value="nisyscfg"/>
 		<prop name="Items" value="system"/>
 	</post>
-	<loadfile srcFile="sysProps.xml" encoding="UTF-16LE" property="roboRIOSysValues"/>
+	<!-- post erroneously turns UTF-16LE 0x0A00 (LF) into non-UTF16
+	0x0D0A00 (CRLF), so do a poor man's conversion from UTF-16 by just
+	removing all the nul characters. -->
+	<propertyregex property="roboRIOSysValues" input="${roboRIOSysValuesUTF16}" regexp="\x00" replace="" global="true" defaultValue="${roboRIOSysValuesUTF16}"/>
 	<propertyregex property="roboRIOImage" input="${roboRIOSysValues}" regexp="FRC_roboRIO_[0-9]+_v([0-9]+)" select="\1" defaultValue="ImageRegExFail"/>
 	<propertyregex property="roboRIOImageYear" input="${roboRIOSysValues}" regexp="FRC_roboRIO_([0-9]+)_v" select="\1" defaultValue="ImageRegExFail"/>
 	<assert message="Image of roboRIO does not match plugin. ${line.separator}Allowed image year: ${roboRIOAllowedYear} version: ${roboRIOAllowedImages}. ${line.separator}Actual image year: ${roboRIOImageYear} version ${roboRIOImage}. ${line.separator}RoboRIO needs to be re-imaged or plugins updated.">

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -267,12 +267,15 @@
 
   <target name="dependencies" depends="get-target-ip">
     <property name="ant.enable.asserts" value="true"/>
-	<post to="http://${target}/nisysapi/server" logfile="sysProps.xml" verbose="false" encoding="UTF-16LE" append="false">
+	<post to="http://${target}/nisysapi/server" property="roboRIOSysValuesUTF16" verbose="false" encoding="UTF-16LE" append="false">
 		<prop name="Function" value="GetPropertiesOfItem"/>
 		<prop name="Plugins" value="nisyscfg"/>
 		<prop name="Items" value="system"/>
 	</post>
-	<loadfile srcFile="sysProps.xml" encoding="UTF-16LE" property="roboRIOSysValues"/>
+	<!-- post erroneously turns UTF-16LE 0x0A00 (LF) into non-UTF16
+	0x0D0A00 (CRLF), so do a poor man's conversion from UTF-16 by just
+	removing all the nul characters. -->
+	<propertyregex property="roboRIOSysValues" input="${roboRIOSysValuesUTF16}" regexp="\x00" replace="" global="true" defaultValue="${roboRIOSysValuesUTF16}"/>
 	<propertyregex property="roboRIOImage" input="${roboRIOSysValues}" regexp="FRC_roboRIO_[0-9]+_v([0-9]+)" select="\1" defaultValue="ImageRegExFail"/>
 	<propertyregex property="roboRIOImageYear" input="${roboRIOSysValues}" regexp="FRC_roboRIO_([0-9]+)_v" select="\1" defaultValue="ImageRegExFail"/>
 	<assert message="Image of roboRIO does not match plugin. ${line.separator}Allowed image year: ${roboRIOAllowedYear} version: ${roboRIOAllowedImages}. ${line.separator}Actual image year: ${roboRIOImageYear} version ${roboRIOImage}. ${line.separator}RoboRIO needs to be re-imaged or plugins updated.">


### PR DESCRIPTION
EOL usually does not exist in this data, but can be set via the Comments field
of the roboRIO system configuration.

On Windows, the post task erroneously turns UTF-16LE 0x0A00 (LF) in the
returned data into non-UTF16 0x0D0A00 (CRLF).  This causes the UTF16-LE
file read to fail.

Attempts to fix this and still write to a file failed due to similar issues
with other Ant tasks.  Instead, we now keep the data in a property and simply
remove all the nul characters.  While this will corrupt any actual UTF-16
characters, we use a regex to find the version information, which is always
ASCII.