### PR TITLE
Include .java files in the user program jar.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -115,6 +115,8 @@
       </manifest>
       <fileset dir="${build.dir}"
                includes="**/*.class" />
+      <fileset dir="${src.dir}"
+               includes="**/*.java" />
       <zipgroupfileset dir="${build.jars}" />
     </jar>
   </target>


### PR DESCRIPTION
These are small and including these can serve as an emergency backup.