### PR TITLE
Update for 2018v5.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -339,7 +339,7 @@
                  username="${adminUsername}"
                  password="${adminPassword}"
                  trust="true"
-                 command="sed -i -e '/netconsole-launcher/{;N;N;N;N;N;N;d;}' /var/lib/opkg/status; opkg install /tmp/${roboRIOJRE.ipk}; rm /tmp/${roboRIOJRE.ipk}" />
+                 command="opkg install /tmp/${roboRIOJRE.ipk}; rm /tmp/${roboRIOJRE.ipk}" />
       </then>
       <else>
         <echo>JRE installation validated</echo>

--- a/ni_image.properties
+++ b/ni_image.properties
@@ -1,2 +1,2 @@
-roboRIOAllowedImages=4
+roboRIOAllowedImages=5
 roboRIOAllowedYear=2018


### PR DESCRIPTION
This image no longer requires the fix to /var/lib/opkg/status.