### PR TITLE
Switches eclipse to download all artifacts rather then just linuxathena

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/pom.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/pom.xml
@@ -64,7 +64,7 @@
                                 <artifactItem>
                                     <groupId>edu.wpi.first.wpilibc</groupId>
                                     <artifactId>wpilibc</artifactId>
-                                    <classifier>linuxathena</classifier>
+                                    <classifier>all</classifier>
                                     <type>zip</type>
                                     <destFileName>wpilibc.jar</destFileName>
                                 </artifactItem>
@@ -78,14 +78,14 @@
                                 <artifactItem>
                                     <groupId>edu.wpi.first.wpilibc</groupId>
                                     <artifactId>wpilibc-linkscripts</artifactId>
-                                    <classifier>linuxathena</classifier>
+                                    <classifier>all</classifier>
                                     <type>zip</type>
                                     <destFileName>wpilibc-linkscripts.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>edu.wpi.first.hal</groupId>
                                     <artifactId>hal</artifactId>
-                                    <classifier>linuxathena</classifier>
+                                    <classifier>all</classifier>
                                     <type>zip</type>
                                     <destFileName>hal.jar</destFileName>
                                 </artifactItem>
@@ -99,7 +99,7 @@
                                 <artifactItem>
                                     <groupId>edu.wpi.first.cscore</groupId>
                                     <artifactId>cscore-cpp</artifactId>
-                                    <classifier>linuxathena</classifier>
+                                    <classifier>all</classifier>
                                     <type>zip</type>
                                     <destFileName>cscore.jar</destFileName>
                                 </artifactItem>
@@ -113,7 +113,7 @@
                                 <artifactItem>
                                     <groupId>edu.wpi.first.ntcore</groupId>
                                     <artifactId>ntcore-cpp</artifactId>
-                                    <classifier>linuxathena</classifier>
+                                    <classifier>all</classifier>
                                     <type>zip</type>
                                     <destFileName>ntcore.jar</destFileName>
                                 </artifactItem>
@@ -127,7 +127,7 @@
                                 <artifactItem>
                                     <groupId>edu.wpi.first.wpiutil</groupId>
                                     <artifactId>wpiutil-cpp</artifactId>
-                                    <classifier>linuxathena</classifier>
+                                    <classifier>all</classifier>
                                     <type>zip</type>
                                     <destFileName>wpiutil.jar</destFileName>
                                 </artifactItem>
@@ -141,7 +141,7 @@
                                 <artifactItem>
                                     <groupId>org.opencv</groupId>
                                     <artifactId>opencv-cpp</artifactId>
-                                    <classifier>linuxathena</classifier>
+                                    <classifier>all</classifier>
                                     <type>zip</type>
                                     <destFileName>opencv.jar</destFileName>
                                 </artifactItem>
@@ -270,49 +270,49 @@
         <dependency>
             <groupId>edu.wpi.first.wpilibc</groupId>
             <artifactId>wpilibc</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.wpilibc</groupId>
             <artifactId>wpilibc-linkscripts</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.hal</groupId>
             <artifactId>hal</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.cscore</groupId>
             <artifactId>cscore-cpp</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.ntcore</groupId>
             <artifactId>ntcore-cpp</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.wpiutil</groupId>
             <artifactId>wpiutil-cpp</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.opencv</groupId>
             <artifactId>opencv-cpp</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>

--- a/edu.wpi.first.wpilib.plugins.java/pom.xml
+++ b/edu.wpi.first.wpilib.plugins.java/pom.xml
@@ -66,7 +66,7 @@
                           <artifactItem>
                               <groupId>edu.wpi.first.wpilibj</groupId>
                               <artifactId>wpilibj-jniShared</artifactId>
-                              <classifier>linuxathena</classifier>
+                              <classifier>all</classifier>
                               <type>jar</type>
                               <includes>**/*.so,**/*.so.debug</includes>
                               <excludes>**/*.MF,**/*.a,**/*.h</excludes>
@@ -75,7 +75,7 @@
                           <artifactItem>
                               <groupId>edu.wpi.first.cscore</groupId>
                               <artifactId>cscore-cpp</artifactId>
-                              <classifier>linuxathena</classifier>
+                              <classifier>all</classifier>
                               <type>zip</type>
                               <includes>**/*.so,**/*.so.**</includes>
                               <excludes>**/*.MF,**/*.a,**/*.h</excludes>
@@ -84,7 +84,7 @@
                           <artifactItem>
                               <groupId>edu.wpi.first.ntcore</groupId>
                               <artifactId>ntcore-cpp</artifactId>
-                              <classifier>linuxathena</classifier>
+                              <classifier>all</classifier>
                               <type>zip</type>
                               <includes>**/*.so,**/*.so.debug</includes>
                               <excludes>**/*.MF,**/*.a,**/*.h</excludes>
@@ -93,7 +93,7 @@
                           <artifactItem>
                               <groupId>edu.wpi.first.wpiutil</groupId>
                               <artifactId>wpiutil-cpp</artifactId>
-                              <classifier>linuxathena</classifier>
+                              <classifier>all</classifier>
                               <type>zip</type>
                               <includes>**/*.so,**/*.so.debug</includes>
                               <excludes>**/*.MF,**/*.a,**/*.h</excludes>
@@ -102,7 +102,7 @@
                           <artifactItem>
                               <groupId>edu.wpi.first.hal</groupId>
                               <artifactId>hal</artifactId>
-                              <classifier>linuxathena</classifier>
+                              <classifier>all</classifier>
                               <type>zip</type>
                               <includes>**/*.so,**/*.so.debug</includes>
                               <excludes>**/*.MF,**/*.a,**/*.h</excludes>
@@ -111,7 +111,7 @@
                           <artifactItem>
                               <groupId>org.opencv</groupId>
                               <artifactId>opencv-cpp</artifactId>
-                              <classifier>linuxathena</classifier>
+                              <classifier>all</classifier>
                               <type>zip</type>
                               <includes>**/*.so,**/*.so.debug, **/*.so.3.2</includes>
                               <excludes>**/*.MF,**/*.a,**/*.h</excludes>
@@ -332,14 +332,14 @@
             <groupId>edu.wpi.first.wpiutil</groupId>
             <artifactId>wpiutil-cpp</artifactId>
             <version>0.1.0-SNAPSHOT</version>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>edu.wpi.first.hal</groupId>
             <artifactId>hal</artifactId>
             <version>0.1.0-SNAPSHOT</version>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
         </dependency>
 
@@ -348,7 +348,7 @@
             <groupId>edu.wpi.first.ntcore</groupId>
             <artifactId>ntcore-cpp</artifactId>
             <version>0.1.0-SNAPSHOT</version>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -367,7 +367,7 @@
             <groupId>edu.wpi.first.cscore</groupId>
             <artifactId>cscore-cpp</artifactId>
             <version>0.1.0-SNAPSHOT</version>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -385,7 +385,7 @@
         <dependency>
             <groupId>org.opencv</groupId>
             <artifactId>opencv-cpp</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <version>0.1.0-SNAPSHOT</version>
             <type>zip</type>
         </dependency>
@@ -398,7 +398,7 @@
         <dependency>
             <groupId>edu.wpi.first.wpilibj</groupId>
             <artifactId>wpilibj-jniShared</artifactId>
-            <classifier>linuxathena</classifier>
+            <classifier>all</classifier>
             <version>0.1.0-SNAPSHOT</version>
             <type>jar</type>
         </dependency>


### PR DESCRIPTION
Will be useful for simulation, and will be PRing a change to wpiutil to enable an optimization where if it detects the plugins installed, it will use the plugin native libraries rather then needing to extract the JNI files from the jar.