### PR TITLE
Adds JavaDoc and Doxygen docs

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/pom.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/pom.xml
@@ -166,6 +166,12 @@
                                     <type>zip</type>
                                     <destFileName>nilibraries-headers.jar</destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>edu.wpi.first.wpilibc</groupId>
+                                    <artifactId>documentation</artifactId>
+                                    <type>zip</type>
+                                    <destFileName>doxygen.zip</destFileName>
+                                </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
@@ -199,6 +205,24 @@
                                 <property name="version" value="${version-info}.${build-number}"/>
                             </target>
                             <exportAntProperties>true</exportAntProperties>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>unzip-doxygen</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <unzip dest="${cpp-zip}/doxygen">
+                                    <fileset dir="${project.build.directory}">
+                                        <include name="doxygen.zip"/>
+                                    </fileset>
+                                </unzip>
+                                <delete dir="${cpp-zip}/doxygen-jar"/>
+                            </target>
                         </configuration>
                     </execution>
 
@@ -370,6 +394,12 @@
             <groupId>edu.wpi.first.ni-libraries</groupId>
             <artifactId>ni-libraries</artifactId>
             <classifier>headers</classifier>
+            <type>zip</type>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>edu.wpi.first.wpilibc</groupId>
+            <artifactId>documentation</artifactId>
             <type>zip</type>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>

--- a/edu.wpi.first.wpilib.plugins.java/pom.xml
+++ b/edu.wpi.first.wpilib.plugins.java/pom.xml
@@ -206,8 +206,8 @@
                                 <!-- Javadoc -->
                                 <artifactItem>
                                     <groupId>edu.wpi.first.wpilibj</groupId>
-                                    <artifactId>wpilibj-java</artifactId>
-                                    <classifier>javadoc</classifier>
+                                    <artifactId>documentation</artifactId>
+                                    <type>zip</type>
                                     <outputDirectory>${java-zip}/javadoc-jar</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
@@ -257,7 +257,7 @@
                             <target>
                                 <unzip dest="${java-zip}/javadoc">
                                     <fileset dir="${java-zip}/javadoc-jar">
-                                        <include name="*.jar"/>
+                                        <include name="*.zip"/>
                                     </fileset>
                                 </unzip>
                                 <delete dir="${java-zip}/javadoc-jar"/>
@@ -407,6 +407,13 @@
             <artifactId>wpilibj-java</artifactId>
             <version>0.1.0-SNAPSHOT</version>
             <classifier>sources</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>edu.wpi.first.wpilibj</groupId>
+            <artifactId>documentation</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <type>zip</type>
         </dependency>
 
         <!-- Library sources for debugging WPILib on the Athena -->


### PR DESCRIPTION
JavaDocs are now grabbed from the documentation repo instead of wpilib, and cpp is added for the first time.