### PR TITLE
Avoid hammering CPU when disconnected from all networks.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.riolog/src/netconsole2/RioConnector.java
+++ b/edu.wpi.first.wpilib.plugins.riolog/src/netconsole2/RioConnector.java
@@ -28,6 +28,7 @@ public class RioConnector {
   private Socket socket = null;
 
   private static final int CONNECTION_TIMEOUT_MS = 2000;
+  private static final int MIN_TIMEOUT_MS = 2000;
   private static final int TOTAL_TIMEOUT_SEC = 5;
 
   private ILogger logger;
@@ -56,6 +57,7 @@ public class RioConnector {
     startConnect("roboRIO-" + team + "-FRC.lan");
     startConnect("roboRIO-" + team + "-FRC.frc-field.local");
     startDsConnect();
+    startTimeDelay(MIN_TIMEOUT_MS);
 
     // wait for a connection attempt to be successful, or timeout
     lock.lock();
@@ -200,6 +202,18 @@ public class RioConnector {
         //logger.log("Could not connect to " + address.getHostAddress());
       }
     }
+  }
+
+  private void startTimeDelay(int timeout) {
+    startAttempt("timeout", new Thread(() -> {
+      try {
+        Thread.currentThread().sleep(timeout);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        finishAttempt("timeout");
+      }
+    }));
   }
 
   private void startAttempt(String loc, Thread thr) {

--- a/edu.wpi.first.wpilib.plugins.riolog/src/netconsole2/RioConsole.java
+++ b/edu.wpi.first.wpilib.plugins.riolog/src/netconsole2/RioConsole.java
@@ -205,7 +205,7 @@ public class RioConsole {
     sender = new Thread(() -> {
       while (!Thread.interrupted() && !cleanup.get()) {
         try {
-          Thread.currentThread().sleep(2);
+          Thread.currentThread().sleep(2000);
           out.write(emptyFrame);
           out.flush();
         } catch (InterruptedException e) {
@@ -270,7 +270,7 @@ public class RioConsole {
           if (teamNumber == null) {
             try {
               // wait a bit so we don't hammer the CPU
-              Thread.currentThread().sleep(5);
+              Thread.currentThread().sleep(5000);
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
               break;


### PR DESCRIPTION
When disconnected from all networks, RioConnector.connect() was returning near
instantly.  Also fix other timeouts.