### PR TITLE
Remove the ipk before installing it.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -318,7 +318,7 @@
                  username="${adminUsername}"
                  password="${adminPassword}"
                  trust="true"
-                 command="opkg install /tmp/${roboRIOJRE.ipk}; rm /tmp/${roboRIOJRE.ipk}" />
+                 command="opkg remove zulu-jre\*; opkg install /tmp/${roboRIOJRE.ipk}; rm /tmp/${roboRIOJRE.ipk}" />
       </then>
       <else>
         <echo>JRE installation validated</echo>


### PR DESCRIPTION
This makes it easy to force a reinstall: just delete
/usr/local/frc/JRE/bin/java.