### PR TITLE
Revert "Update to compact2 JRE provided by Azul. (#150)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,15 @@ plugins {
 
 import org.apache.commons.codec.digest.DigestUtils
 
-def jreRelease = 'v2018-beta3-compact2'
-def jreFile = 'zulu-jre-compact2_1.8.0-152_cortexa9-vfpv3.ipk'
+def jreRelease = 'v2018-beta2'
+def jreFile = 'zulu-jre_1.8.0-131_cortexa9-vfpv3.ipk'
 
 task downloadJRE() {
     group = 'Build'
     description = 'Downloads JRE ipk.'
 
     def destFile = new File('edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/', jreFile)
-    def golden = '2ab08501e96b60d6d84f713f4e339cdab4bbdbeae1b43a2a4a13f709b3045897'
+    def golden = 'ed3de06560a9ea87c120f83b5d3f1e7e07d841d76b4163c20c99eb6bf0219536'
 
     String checksum
     if (destFile.exists()) {

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.properties
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.properties
@@ -11,7 +11,7 @@ debug.flag.command=chown lvuser:ni ${debug.flag.dir}frcdebug
 command.dir=/home/lvuser/
 version=current
 roboRIOJRE.dir=/usr/local/frc/JRE
-roboRIOJRE.ipk=zulu-jre-compact2_1.8.0-152_cortexa9-vfpv3.ipk
+roboRIOJRE.ipk=zulu-jre_1.8.0-131_cortexa9-vfpv3.ipk
 
 # Libraries to use
 wpilib=${user.home}/wpilib/java/${version}


### PR DESCRIPTION
This reverts commit 5da350ac5b81c4114cdcefd9a22c4c731ea2ea72.

The compact2 JRE does not have JDWP support, which is required for
remote debugging.