### PR TITLE
Add -rdynamic linker flag

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/resources/templates/.cproject
+++ b/edu.wpi.first.wpilib.plugins.cpp/resources/templates/.cproject
@@ -52,7 +52,7 @@
 									<listOptionValue builtIn="false" value="&quot;${WPILIB}/cpp/current/reflib/linux/athena/shared&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${WPILIB}/user/cpp/lib&quot;"/>
 								</option>
-								<option id="gnu.cpp.link.option.flags.675338432" name="Linker flags" superClass="gnu.cpp.link.option.flags" value="-pthread -Wl,-rpath,/opt/GenICam_v3_0_NI/bin/Linux32_ARM,-rpath,/usr/local/frc/lib" valueType="string"/>
+								<option id="gnu.cpp.link.option.flags.675338432" name="Linker flags" superClass="gnu.cpp.link.option.flags" value="-pthread -rdynamic -Wl,-rpath,/opt/GenICam_v3_0_NI/bin/Linux32_ARM,-rpath,/usr/local/frc/lib" valueType="string"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.132949138" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>

--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/java/edu/wpi/first/wpilib/plugins/cpp/WPILibCPPPlugin.java
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/java/edu/wpi/first/wpilib/plugins/cpp/WPILibCPPPlugin.java
@@ -42,7 +42,7 @@ public class WPILibCPPPlugin extends AbstractUIPlugin implements IStartup {
 	private static final String REF_LIBS_PATH = "\"${WPILIB}/cpp/current/reflib/linux/athena/shared\"";
 	private static final String USER_INCLUDE_PATH = "\"${WPILIB}/user/cpp/include\"";
 	private static final String COMPILER_OPTIONS = "-c -fmessage-length=0 -pthread";
-	private static final String LINKER_OPTIONS = "-pthread -Wl,-rpath,/opt/GenICam_v3_0_NI/bin/Linux32_ARM,-rpath,/usr/local/frc/lib";
+	private static final String LINKER_OPTIONS = "-pthread -rdynamic -Wl,-rpath,/opt/GenICam_v3_0_NI/bin/Linux32_ARM,-rpath,/usr/local/frc/lib";
 
 	// The shared instance
 	private static WPILibCPPPlugin plugin;


### PR DESCRIPTION
Adds -rdynamic flag to linker settings. This is needed for backtraces to work properly.