### PR TITLE
Revert "Riolog: Image v13 doesn't handle keepalives properly; disable…

### DIFF
--- a/edu.wpi.first.wpilib.plugins.riolog/src/netconsole2/RioConsole.java
+++ b/edu.wpi.first.wpilib.plugins.riolog/src/netconsole2/RioConsole.java
@@ -221,8 +221,7 @@ public class RioConsole {
         sender = null;
       }, "RioConsoleSender");
       sender.setDaemon(true);
-      // For image 2018v13, don't send keep alives
-      //sender.start();
+      sender.start();
     }
     return in;
   }


### PR DESCRIPTION
…. (#164)"

This reverts commit 66f3803a9bb53e9a30851a4deedcc718426d7d19.