### PR TITLE
Include all src files in java .jar, not just .java files.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -114,8 +114,7 @@
       </manifest>
       <fileset dir="${build.dir}"
                includes="**/*.class" />
-      <fileset dir="${src.dir}"
-               includes="**/*.java" />
+      <fileset dir="${src.dir}" />
       <zipgroupfileset dir="${build.jars}" />
     </jar>
   </target>


### PR DESCRIPTION
Fixes #174.