### PR TITLE
Don't recursively copy from userlibs.

### DIFF
--- a/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.cpp/src/main/resources/cpp-zip/ant/build.xml
@@ -88,7 +88,7 @@
                  libs.deployDir="${libDeploy.dir}">
       <libs.local>
         <fileset dir="${userLibs.dir}">
-          <include name="**/*.so" />
+          <include name="*.so" />
         </fileset>
       </libs.local>
     </deploy-libs>
@@ -141,7 +141,7 @@
                  libs.deployDir="${libDeploy.dir}">
       <libs.local>
         <fileset dir="${userLibs.dir}">
-          <include name="**/*.so" />
+          <include name="*.so" />
         </fileset>
       </libs.local>
     </deploy-libs>

--- a/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
+++ b/edu.wpi.first.wpilib.plugins.java/src/main/resources/java-zip/ant/build.xml
@@ -148,7 +148,7 @@
                  libs.deployDir="${libDeploy.dir}">
       <libs.local>
         <fileset dir="${userLibs.dir}">
-          <include name="**/*.so" />
+          <include name="*.so" />
         </fileset>
       </libs.local>
     </deploy-libs>
@@ -197,7 +197,7 @@
                  libs.deployDir="${libDeploy.dir}">
       <libs.local>
         <fileset dir="${userLibs.dir}">
-          <include name="**/*.so" />
+          <include name="*.so" />
         </fileset>
       </libs.local>
     </deploy-libs>


### PR DESCRIPTION
Currently the subpaths created by subdirectories aren't handled correctly by
the unix scripts.  As we're copying into a flat namespace, conflicting
filenames can't be resolved, so it's better to simply ignore files in
subdirectories.